### PR TITLE
feat: add CI workflow with Biome linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Lint, Typecheck & Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          cache: true
+
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"includes": ["**", "!!**/dist"]
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "dev": "tsx src/index.ts",
     "build": "tsup",
     "start": "node dist/index.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check src",
+    "lint:fix": "biome check --write src",
+    "format": "biome format --write src"
   },
   "keywords": [
     "github",
@@ -37,6 +40,7 @@
     "execa": "^9.6.1"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.3.10",
     "@types/node": "^25.0.3",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
         specifier: ^9.6.1
         version: 9.6.1
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.3.10
+        version: 2.3.10
       '@types/node':
         specifier: ^25.0.3
         version: 25.0.3
@@ -35,6 +38,63 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@biomejs/biome@2.3.10':
+    resolution: {integrity: sha512-/uWSUd1MHX2fjqNLHNL6zLYWBbrJeG412/8H7ESuK8ewoRoMPUgHDebqKrPTx/5n6f17Xzqc9hdg3MEqA5hXnQ==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.3.10':
+    resolution: {integrity: sha512-M6xUjtCVnNGFfK7HMNKa593nb7fwNm43fq1Mt71kpLpb+4mE7odO8W/oWVDyBVO4ackhresy1ZYO7OJcVo/B7w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.3.10':
+    resolution: {integrity: sha512-Vae7+V6t/Avr8tVbFNjnFSTKZogZHFYl7MMH62P/J1kZtr0tyRQ9Fe0onjqjS2Ek9lmNLmZc/VR5uSekh+p1fg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.3.10':
+    resolution: {integrity: sha512-B9DszIHkuKtOH2IFeeVkQmSMVUjss9KtHaNXquYYWCjH8IstNgXgx5B0aSBQNr6mn4RcKKRQZXn9Zu1rM3O0/A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.3.10':
+    resolution: {integrity: sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.3.10':
+    resolution: {integrity: sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.3.10':
+    resolution: {integrity: sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.3.10':
+    resolution: {integrity: sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.3.10':
+    resolution: {integrity: sha512-pHEFgq7dUEsKnqG9mx9bXihxGI49X+ar+UBrEIj3Wqj3UCZp1rNgV+OoyjFgcXsjCWpuEAF4VJdkZr3TrWdCbQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -825,6 +885,41 @@ packages:
     engines: {node: '>=18'}
 
 snapshots:
+
+  '@biomejs/biome@2.3.10':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.3.10
+      '@biomejs/cli-darwin-x64': 2.3.10
+      '@biomejs/cli-linux-arm64': 2.3.10
+      '@biomejs/cli-linux-arm64-musl': 2.3.10
+      '@biomejs/cli-linux-x64': 2.3.10
+      '@biomejs/cli-linux-x64-musl': 2.3.10
+      '@biomejs/cli-win32-arm64': 2.3.10
+      '@biomejs/cli-win32-x64': 2.3.10
+
+  '@biomejs/cli-darwin-arm64@2.3.10':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.3.10':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.3.10':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.3.10':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.3.10':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.3.10':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.3.10':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.3.10':
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -10,21 +10,21 @@ const summaryPromptDe = `Basierend auf diesen GitHub-Aktivitätsdaten, schreibe 
 GitHub-Aktivitätsdaten:`;
 
 export async function generateSummaryText(
-  activity: GitHubActivity,
-  lang: Language,
-  model?: string
+	activity: GitHubActivity,
+	lang: Language,
+	model?: string,
 ): Promise<string> {
-  const prompt = lang === "en" ? summaryPromptEn : summaryPromptDe;
-  const fullPrompt = `${prompt}\n${JSON.stringify(activity, null, 2)}`;
+	const prompt = lang === "en" ? summaryPromptEn : summaryPromptDe;
+	const fullPrompt = `${prompt}\n${JSON.stringify(activity, null, 2)}`;
 
-  const args = ["-p", "-", "--output-format", "text"];
-  if (model) {
-    args.push("--model", model);
-  }
+	const args = ["-p", "-", "--output-format", "text"];
+	if (model) {
+		args.push("--model", model);
+	}
 
-  const { stdout } = await execa("claude", args, {
-    input: fullPrompt,
-  });
+	const { stdout } = await execa("claude", args, {
+		input: fullPrompt,
+	});
 
-  return stdout.trim();
+	return stdout.trim();
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,294 +1,298 @@
 import { execa } from "execa";
 import type {
-  GitHubActivity,
-  PullRequest,
-  Issue,
-  Commit,
-  RepoInfo,
+	Commit,
+	GitHubActivity,
+	Issue,
+	PullRequest,
+	RepoInfo,
 } from "./types.js";
 
 function getSinceDate(days: number): string {
-  const date = new Date();
-  date.setDate(date.getDate() - days);
-  return date.toISOString();
+	const date = new Date();
+	date.setDate(date.getDate() - days);
+	return date.toISOString();
 }
 
 function formatDate(date: Date): string {
-  const day = date.getDate().toString().padStart(2, "0");
-  const month = (date.getMonth() + 1).toString().padStart(2, "0");
-  const year = date.getFullYear();
-  return `${day}.${month}.${year}`;
+	const day = date.getDate().toString().padStart(2, "0");
+	const month = (date.getMonth() + 1).toString().padStart(2, "0");
+	const year = date.getFullYear();
+	return `${day}.${month}.${year}`;
 }
 
 async function ghApi<T>(
-  endpoint: string,
-  params: Record<string, string>
+	endpoint: string,
+	params: Record<string, string>,
 ): Promise<T> {
-  const args = [
-    "api",
-    "-X",
-    "GET",
-    endpoint,
-    ...Object.entries(params).flatMap(([key, value]) => ["-f", `${key}=${value}`]),
-  ];
+	const args = [
+		"api",
+		"-X",
+		"GET",
+		endpoint,
+		...Object.entries(params).flatMap(([key, value]) => [
+			"-f",
+			`${key}=${value}`,
+		]),
+	];
 
-  const { stdout } = await execa("gh", args);
-  return JSON.parse(stdout) as T;
+	const { stdout } = await execa("gh", args);
+	return JSON.parse(stdout) as T;
 }
 
 async function ghApiPaginated<T>(
-  endpoint: string,
-  params: Record<string, string>,
-  maxPages: number = 10
+	endpoint: string,
+	params: Record<string, string>,
+	maxPages: number = 10,
 ): Promise<T[]> {
-  const allItems: T[] = [];
-  let page = 1;
+	const allItems: T[] = [];
+	let page = 1;
 
-  while (page <= maxPages) {
-    const result = await ghApi<SearchResult<T>>(endpoint, {
-      ...params,
-      page: String(page),
-      per_page: "100",
-    });
+	while (page <= maxPages) {
+		const result = await ghApi<SearchResult<T>>(endpoint, {
+			...params,
+			page: String(page),
+			per_page: "100",
+		});
 
-    allItems.push(...result.items);
+		allItems.push(...result.items);
 
-    if (result.items.length < 100) {
-      break;
-    }
-    page++;
-  }
+		if (result.items.length < 100) {
+			break;
+		}
+		page++;
+	}
 
-  return allItems;
+	return allItems;
 }
 
 interface SearchResult<T> {
-  total_count?: number;
-  items: T[];
+	total_count?: number;
+	items: T[];
 }
 
 interface RawPR {
-  repository_url: string;
-  title: string;
-  number: number;
-  state: string;
-  html_url: string;
+	repository_url: string;
+	title: string;
+	number: number;
+	state: string;
+	html_url: string;
 }
 
 interface RawCommit {
-  repository: {
-    name: string;
-    owner: { login: string };
-  };
-  commit: { message: string };
-  html_url: string;
+	repository: {
+		name: string;
+		owner: { login: string };
+	};
+	commit: { message: string };
+	html_url: string;
 }
 
 interface RawRepo {
-  name: string;
-  owner: { login: string };
-  created_at: string;
-  html_url: string;
+	name: string;
+	owner: { login: string };
+	created_at: string;
+	html_url: string;
 }
 
 function parsePR(item: RawPR): PullRequest {
-  const urlParts = item.repository_url.split("/");
-  return {
-    repo: urlParts[urlParts.length - 1],
-    org: urlParts[urlParts.length - 2],
-    title: item.title,
-    number: item.number,
-    state: item.state,
-    url: item.html_url,
-  };
+	const urlParts = item.repository_url.split("/");
+	return {
+		repo: urlParts[urlParts.length - 1],
+		org: urlParts[urlParts.length - 2],
+		title: item.title,
+		number: item.number,
+		state: item.state,
+		url: item.html_url,
+	};
 }
 
 function parseIssue(item: RawPR): Issue {
-  const urlParts = item.repository_url.split("/");
-  return {
-    repo: urlParts[urlParts.length - 1],
-    org: urlParts[urlParts.length - 2],
-    title: item.title,
-    number: item.number,
-    url: item.html_url,
-  };
+	const urlParts = item.repository_url.split("/");
+	return {
+		repo: urlParts[urlParts.length - 1],
+		org: urlParts[urlParts.length - 2],
+		title: item.title,
+		number: item.number,
+		url: item.html_url,
+	};
 }
 
 function parseCommit(item: RawCommit): Commit {
-  return {
-    repo: item.repository.name,
-    org: item.repository.owner.login,
-    message: item.commit.message.split("\n")[0],
-    url: item.html_url,
-  };
+	return {
+		repo: item.repository.name,
+		org: item.repository.owner.login,
+		message: item.commit.message.split("\n")[0],
+		url: item.html_url,
+	};
 }
 
 export async function getAuthenticatedUser(): Promise<string> {
-  const { stdout } = await execa("gh", ["api", "user", "--jq", ".login"]);
-  return stdout.trim();
+	const { stdout } = await execa("gh", ["api", "user", "--jq", ".login"]);
+	return stdout.trim();
 }
 
 async function fetchUserOrgs(username: string): Promise<string[]> {
-  // First try authenticated user's orgs (includes private memberships)
-  try {
-    const authUser = await getAuthenticatedUser();
-    if (authUser === username) {
-      const { stdout } = await execa("gh", [
-        "api",
-        "user/orgs",
-        "--jq",
-        ".[].login",
-      ]);
-      return stdout.trim().split("\n").filter(Boolean);
-    }
-  } catch {
-    // Fall through to public orgs
-  }
+	// First try authenticated user's orgs (includes private memberships)
+	try {
+		const authUser = await getAuthenticatedUser();
+		if (authUser === username) {
+			const { stdout } = await execa("gh", [
+				"api",
+				"user/orgs",
+				"--jq",
+				".[].login",
+			]);
+			return stdout.trim().split("\n").filter(Boolean);
+		}
+	} catch {
+		// Fall through to public orgs
+	}
 
-  // Fallback to public orgs for other users
-  try {
-    const { stdout } = await execa("gh", [
-      "api",
-      `users/${username}/orgs`,
-      "--jq",
-      ".[].login",
-    ]);
-    return stdout.trim().split("\n").filter(Boolean);
-  } catch {
-    return [];
-  }
+	// Fallback to public orgs for other users
+	try {
+		const { stdout } = await execa("gh", [
+			"api",
+			`users/${username}/orgs`,
+			"--jq",
+			".[].login",
+		]);
+		return stdout.trim().split("\n").filter(Boolean);
+	} catch {
+		return [];
+	}
 }
 
 async function fetchReposCreatedSince(
-  username: string,
-  since: string,
-  publicOnly: boolean
+	username: string,
+	since: string,
+	publicOnly: boolean,
 ): Promise<RepoInfo[]> {
-  const sinceDate = new Date(since);
-  const repos: RepoInfo[] = [];
+	const sinceDate = new Date(since);
+	const repos: RepoInfo[] = [];
 
-  // Fetch user's own repos
-  try {
-    const visibility = publicOnly ? "public" : "all";
-    const { stdout } = await execa("gh", [
-      "api",
-      `users/${username}/repos?type=${visibility}&sort=created&direction=desc&per_page=100`,
-    ]);
-    const userRepos = JSON.parse(stdout) as RawRepo[];
-    for (const repo of userRepos) {
-      if (new Date(repo.created_at) >= sinceDate) {
-        repos.push({ name: repo.name, org: repo.owner.login });
-      }
-    }
-  } catch {
-    // Ignore errors for user repos
-  }
+	// Fetch user's own repos
+	try {
+		const visibility = publicOnly ? "public" : "all";
+		const { stdout } = await execa("gh", [
+			"api",
+			`users/${username}/repos?type=${visibility}&sort=created&direction=desc&per_page=100`,
+		]);
+		const userRepos = JSON.parse(stdout) as RawRepo[];
+		for (const repo of userRepos) {
+			if (new Date(repo.created_at) >= sinceDate) {
+				repos.push({ name: repo.name, org: repo.owner.login });
+			}
+		}
+	} catch {
+		// Ignore errors for user repos
+	}
 
-  // Fetch repos from user's orgs
-  const orgs = await fetchUserOrgs(username);
-  for (const org of orgs) {
-    try {
-      const { stdout } = await execa("gh", [
-        "api",
-        `orgs/${org}/repos?sort=created&direction=desc&per_page=100`,
-      ]);
-      const orgRepos = JSON.parse(stdout) as RawRepo[];
-      for (const repo of orgRepos) {
-        if (new Date(repo.created_at) >= sinceDate) {
-          repos.push({ name: repo.name, org: repo.owner.login });
-        }
-      }
-    } catch {
-      // Ignore errors for individual orgs
-    }
-  }
+	// Fetch repos from user's orgs
+	const orgs = await fetchUserOrgs(username);
+	for (const org of orgs) {
+		try {
+			const { stdout } = await execa("gh", [
+				"api",
+				`orgs/${org}/repos?sort=created&direction=desc&per_page=100`,
+			]);
+			const orgRepos = JSON.parse(stdout) as RawRepo[];
+			for (const repo of orgRepos) {
+				if (new Date(repo.created_at) >= sinceDate) {
+					repos.push({ name: repo.name, org: repo.owner.login });
+				}
+			}
+		} catch {
+			// Ignore errors for individual orgs
+		}
+	}
 
-  // Deduplicate
-  return repos.filter(
-    (repo, index, self) =>
-      self.findIndex((r) => r.name === repo.name && r.org === repo.org) === index
-  );
+	// Deduplicate
+	return repos.filter(
+		(repo, index, self) =>
+			self.findIndex((r) => r.name === repo.name && r.org === repo.org) ===
+			index,
+	);
 }
 
 export async function fetchGitHubActivity(
-  username: string,
-  days: number,
-  publicOnly: boolean
+	username: string,
+	days: number,
+	publicOnly: boolean,
 ): Promise<GitHubActivity> {
-  const since = getSinceDate(days);
-  const today = formatDate(new Date());
-  const visibilityFilter = publicOnly ? " is:public" : "";
+	const since = getSinceDate(days);
+	const today = formatDate(new Date());
+	const visibilityFilter = publicOnly ? " is:public" : "";
 
-  // Fetch all data in parallel with pagination
-  const [
-    prsCreatedItems,
-    prsMergedItems,
-    prsReviewedItems,
-    issuesCreatedItems,
-    issuesClosedItems,
-    commitsItems,
-    repos_created,
-  ] = await Promise.all([
-    ghApiPaginated<RawPR>("search/issues", {
-      q: `author:${username} type:pr created:>=${since}${visibilityFilter}`,
-    }),
-    ghApiPaginated<RawPR>("search/issues", {
-      q: `author:${username} type:pr merged:>=${since}${visibilityFilter}`,
-    }),
-    ghApiPaginated<RawPR>("search/issues", {
-      q: `reviewed-by:${username} type:pr created:>=${since} -author:${username}${visibilityFilter}`,
-    }),
-    ghApiPaginated<RawPR>("search/issues", {
-      q: `author:${username} type:issue created:>=${since}${visibilityFilter}`,
-    }),
-    ghApiPaginated<RawPR>("search/issues", {
-      q: `author:${username} type:issue closed:>=${since}${visibilityFilter}`,
-    }),
-    ghApiPaginated<RawCommit>("search/commits", {
-      q: `author:${username} committer-date:>=${since}`,
-    }),
-    fetchReposCreatedSince(username, since, publicOnly),
-  ]);
+	// Fetch all data in parallel with pagination
+	const [
+		prsCreatedItems,
+		prsMergedItems,
+		prsReviewedItems,
+		issuesCreatedItems,
+		issuesClosedItems,
+		commitsItems,
+		repos_created,
+	] = await Promise.all([
+		ghApiPaginated<RawPR>("search/issues", {
+			q: `author:${username} type:pr created:>=${since}${visibilityFilter}`,
+		}),
+		ghApiPaginated<RawPR>("search/issues", {
+			q: `author:${username} type:pr merged:>=${since}${visibilityFilter}`,
+		}),
+		ghApiPaginated<RawPR>("search/issues", {
+			q: `reviewed-by:${username} type:pr created:>=${since} -author:${username}${visibilityFilter}`,
+		}),
+		ghApiPaginated<RawPR>("search/issues", {
+			q: `author:${username} type:issue created:>=${since}${visibilityFilter}`,
+		}),
+		ghApiPaginated<RawPR>("search/issues", {
+			q: `author:${username} type:issue closed:>=${since}${visibilityFilter}`,
+		}),
+		ghApiPaginated<RawCommit>("search/commits", {
+			q: `author:${username} committer-date:>=${since}`,
+		}),
+		fetchReposCreatedSince(username, since, publicOnly),
+	]);
 
-  const prs_created = prsCreatedItems.map(parsePR);
-  const prs_merged = prsMergedItems.map(parsePR);
-  const prs_reviewed = prsReviewedItems.map(parsePR);
-  const issues_created = issuesCreatedItems.map(parseIssue);
-  const issues_closed = issuesClosedItems.map(parseIssue);
-  const commits = commitsItems.map(parseCommit);
+	const prs_created = prsCreatedItems.map(parsePR);
+	const prs_merged = prsMergedItems.map(parsePR);
+	const prs_reviewed = prsReviewedItems.map(parsePR);
+	const issues_created = issuesCreatedItems.map(parseIssue);
+	const issues_closed = issuesClosedItems.map(parseIssue);
+	const commits = commitsItems.map(parseCommit);
 
-  // Extract unique repos touched
-  const allRepos = [
-    ...prs_created,
-    ...prs_merged,
-    ...prs_reviewed,
-    ...issues_created,
-    ...issues_closed,
-    ...commits,
-  ].map((item) => `${item.org}/${item.repo}`);
+	// Extract unique repos touched
+	const allRepos = [
+		...prs_created,
+		...prs_merged,
+		...prs_reviewed,
+		...issues_created,
+		...issues_closed,
+		...commits,
+	].map((item) => `${item.org}/${item.repo}`);
 
-  const repos_touched = [...new Set(allRepos)];
+	const repos_touched = [...new Set(allRepos)];
 
-  const periodText =
-    days === 1
-      ? "last 24 hours"
-      : days === 7
-        ? "last 7 days"
-        : days === 30
-          ? "last 30 days"
-          : `last ${days} days`;
+	const periodText =
+		days === 1
+			? "last 24 hours"
+			: days === 7
+				? "last 7 days"
+				: days === 30
+					? "last 30 days"
+					: `last ${days} days`;
 
-  return {
-    user: username,
-    date: today,
-    period: periodText,
-    prs_created,
-    prs_merged,
-    prs_reviewed,
-    issues_created,
-    issues_closed,
-    commits,
-    repos_created,
-    repos_touched,
-  };
+	return {
+		user: username,
+		date: today,
+		period: periodText,
+		prs_created,
+		prs_merged,
+		prs_reviewed,
+		issues_created,
+		issues_closed,
+		commits,
+		repos_created,
+		repos_touched,
+	};
 }

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -1,66 +1,66 @@
-import { input, select, confirm } from "@inquirer/prompts";
-import type { OutputFormat, Language } from "./types.js";
+import { confirm, input, select } from "@inquirer/prompts";
+import type { Language, OutputFormat } from "./types.js";
 
 interface InteractiveOptions {
-  username: string;
-  days: number;
-  language: Language;
-  format: OutputFormat;
-  includePrivate: boolean;
-  model: string;
+	username: string;
+	days: number;
+	language: Language;
+	format: OutputFormat;
+	includePrivate: boolean;
+	model: string;
 }
 
 export async function runInteractive(): Promise<InteractiveOptions> {
-  const username = await input({
-    message: "GitHub username (leave empty for authenticated user)",
-    default: "",
-  });
+	const username = await input({
+		message: "GitHub username (leave empty for authenticated user)",
+		default: "",
+	});
 
-  const days = await select({
-    message: "Time period",
-    choices: [
-      { name: "Last 24 hours", value: 1 },
-      { name: "Last 7 days", value: 7 },
-      { name: "Last 30 days", value: 30 },
-    ],
-    default: 1,
-  });
+	const days = await select({
+		message: "Time period",
+		choices: [
+			{ name: "Last 24 hours", value: 1 },
+			{ name: "Last 7 days", value: 7 },
+			{ name: "Last 30 days", value: 30 },
+		],
+		default: 1,
+	});
 
-  const language = await select({
-    message: "Language",
-    choices: [
-      { name: "English", value: "en" as Language },
-      { name: "German", value: "de" as Language },
-    ],
-    default: "en" as Language,
-  });
+	const language = await select({
+		message: "Language",
+		choices: [
+			{ name: "English", value: "en" as Language },
+			{ name: "German", value: "de" as Language },
+		],
+		default: "en" as Language,
+	});
 
-  const format = await select({
-    message: "Output format",
-    choices: [
-      { name: "Plain text", value: "plain" as OutputFormat },
-      { name: "Markdown", value: "markdown" as OutputFormat },
-      { name: "Slack", value: "slack" as OutputFormat },
-    ],
-    default: "plain" as OutputFormat,
-  });
+	const format = await select({
+		message: "Output format",
+		choices: [
+			{ name: "Plain text", value: "plain" as OutputFormat },
+			{ name: "Markdown", value: "markdown" as OutputFormat },
+			{ name: "Slack", value: "slack" as OutputFormat },
+		],
+		default: "plain" as OutputFormat,
+	});
 
-  const includePrivate = await confirm({
-    message: "Include private repos?",
-    default: true,
-  });
+	const includePrivate = await confirm({
+		message: "Include private repos?",
+		default: true,
+	});
 
-  const model = await input({
-    message: "Claude model (leave empty for default)",
-    default: "",
-  });
+	const model = await input({
+		message: "Claude model (leave empty for default)",
+		default: "",
+	});
 
-  return {
-    username,
-    days,
-    language,
-    format,
-    includePrivate,
-    model,
-  };
+	return {
+		username,
+		days,
+		language,
+		format,
+		includePrivate,
+		model,
+	};
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,133 +1,128 @@
-import type { GitHubActivity, OutputFormat, Language } from "./types.js";
+import type { GitHubActivity, Language, OutputFormat } from "./types.js";
 
 function getRepoNames(items: { repo: string }[]): string {
-  const repos = [...new Set(items.map((i) => i.repo))];
-  return repos.join(", ");
+	const repos = [...new Set(items.map((i) => i.repo))];
+	return repos.join(", ");
 }
 
 function formatActivityLine(
-  count: number,
-  labelEn: string,
-  labelDe: string,
-  repos: string,
-  lang: Language,
-  format: OutputFormat
+	count: number,
+	labelEn: string,
+	labelDe: string,
+	repos: string,
+	lang: Language,
+	format: OutputFormat,
 ): string | null {
-  if (count === 0) return null;
+	if (count === 0) return null;
 
-  const label = lang === "en" ? labelEn : labelDe;
-  const repoSuffix = repos ? ` (${repos})` : "";
+	const label = lang === "en" ? labelEn : labelDe;
+	const repoSuffix = repos ? ` (${repos})` : "";
 
-  switch (format) {
-    case "markdown":
-      return `- **${count}** ${label}${repoSuffix}`;
-    case "plain":
-      return `• ${count} ${label}${repoSuffix}`;
-    case "slack":
-    default:
-      return `• ${count} ${label}${repoSuffix}`;
-  }
+	if (format === "markdown") {
+		return `- **${count}** ${label}${repoSuffix}`;
+	}
+	return `• ${count} ${label}${repoSuffix}`;
 }
 
 export function formatActivity(
-  activity: GitHubActivity,
-  format: OutputFormat,
-  lang: Language
+	activity: GitHubActivity,
+	format: OutputFormat,
+	lang: Language,
 ): string {
-  const lines: string[] = [];
+	const lines: string[] = [];
 
-  // Header
-  const headerPrefix = format === "markdown" ? "## " : "";
-  lines.push(`${headerPrefix}tl;dr ${activity.date}`);
-  lines.push("");
+	// Header
+	const headerPrefix = format === "markdown" ? "## " : "";
+	lines.push(`${headerPrefix}tl;dr ${activity.date}`);
+	lines.push("");
 
-  const activityLines = [
-    formatActivityLine(
-      activity.prs_created.length,
-      "PRs created",
-      "PRs erstellt",
-      getRepoNames(activity.prs_created),
-      lang,
-      format
-    ),
-    formatActivityLine(
-      activity.prs_reviewed.length,
-      "PRs reviewed",
-      "PRs reviewed/approved",
-      getRepoNames(activity.prs_reviewed),
-      lang,
-      format
-    ),
-    formatActivityLine(
-      activity.prs_merged.length,
-      "PRs merged",
-      "PRs gemerged",
-      getRepoNames(activity.prs_merged),
-      lang,
-      format
-    ),
-    formatActivityLine(
-      activity.issues_created.length,
-      "issues created",
-      "Issues erstellt",
-      getRepoNames(activity.issues_created),
-      lang,
-      format
-    ),
-    formatActivityLine(
-      activity.issues_closed.length,
-      "issues closed",
-      "Issues geschlossen",
-      getRepoNames(activity.issues_closed),
-      lang,
-      format
-    ),
-    formatActivityLine(
-      activity.commits.length,
-      "commits",
-      "Commits",
-      getRepoNames(activity.commits),
-      lang,
-      format
-    ),
-    formatActivityLine(
-      activity.repos_created.length,
-      "new repos created",
-      "neue Repos erstellt",
-      activity.repos_created.map((r) => r.name).join(", "),
-      lang,
-      format
-    ),
-  ].filter(Boolean) as string[];
+	const activityLines = [
+		formatActivityLine(
+			activity.prs_created.length,
+			"PRs created",
+			"PRs erstellt",
+			getRepoNames(activity.prs_created),
+			lang,
+			format,
+		),
+		formatActivityLine(
+			activity.prs_reviewed.length,
+			"PRs reviewed",
+			"PRs reviewed/approved",
+			getRepoNames(activity.prs_reviewed),
+			lang,
+			format,
+		),
+		formatActivityLine(
+			activity.prs_merged.length,
+			"PRs merged",
+			"PRs gemerged",
+			getRepoNames(activity.prs_merged),
+			lang,
+			format,
+		),
+		formatActivityLine(
+			activity.issues_created.length,
+			"issues created",
+			"Issues erstellt",
+			getRepoNames(activity.issues_created),
+			lang,
+			format,
+		),
+		formatActivityLine(
+			activity.issues_closed.length,
+			"issues closed",
+			"Issues geschlossen",
+			getRepoNames(activity.issues_closed),
+			lang,
+			format,
+		),
+		formatActivityLine(
+			activity.commits.length,
+			"commits",
+			"Commits",
+			getRepoNames(activity.commits),
+			lang,
+			format,
+		),
+		formatActivityLine(
+			activity.repos_created.length,
+			"new repos created",
+			"neue Repos erstellt",
+			activity.repos_created.map((r) => r.name).join(", "),
+			lang,
+			format,
+		),
+	].filter(Boolean) as string[];
 
-  if (activityLines.length === 0) {
-    const noActivity =
-      lang === "en"
-        ? `No GitHub activity in the ${activity.period}.`
-        : `Keine GitHub-Aktivität in den ${activity.period}.`;
-    lines.push(noActivity);
-    return lines.join("\n");
-  }
+	if (activityLines.length === 0) {
+		const noActivity =
+			lang === "en"
+				? `No GitHub activity in the ${activity.period}.`
+				: `Keine GitHub-Aktivität in den ${activity.period}.`;
+		lines.push(noActivity);
+		return lines.join("\n");
+	}
 
-  lines.push(...activityLines);
-  lines.push("");
+	lines.push(...activityLines);
+	lines.push("");
 
-  // Repos touched
-  if (activity.repos_touched.length > 0) {
-    const reposLabel = lang === "en" ? "Repos" : "Repos";
-    lines.push(`${reposLabel}: ${activity.repos_touched.join(", ")}`);
-  }
+	// Repos touched
+	if (activity.repos_touched.length > 0) {
+		const reposLabel = lang === "en" ? "Repos" : "Repos";
+		lines.push(`${reposLabel}: ${activity.repos_touched.join(", ")}`);
+	}
 
-  return lines.join("\n");
+	return lines.join("\n");
 }
 
 export function hasActivity(activity: GitHubActivity): boolean {
-  return (
-    activity.prs_created.length +
-      activity.prs_merged.length +
-      activity.prs_reviewed.length +
-      activity.issues_created.length +
-      activity.issues_closed.length >
-    0
-  );
+	return (
+		activity.prs_created.length +
+			activity.prs_merged.length +
+			activity.prs_reviewed.length +
+			activity.issues_created.length +
+			activity.issues_closed.length >
+		0
+	);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,54 +1,54 @@
 export interface PullRequest {
-  repo: string;
-  org: string;
-  title: string;
-  number: number;
-  state?: string;
-  url: string;
+	repo: string;
+	org: string;
+	title: string;
+	number: number;
+	state?: string;
+	url: string;
 }
 
 export interface Issue {
-  repo: string;
-  org: string;
-  title: string;
-  number: number;
-  url: string;
+	repo: string;
+	org: string;
+	title: string;
+	number: number;
+	url: string;
 }
 
 export interface Commit {
-  repo: string;
-  org: string;
-  message: string;
-  url: string;
+	repo: string;
+	org: string;
+	message: string;
+	url: string;
 }
 
 export interface RepoInfo {
-  name: string;
-  org: string;
+	name: string;
+	org: string;
 }
 
 export interface GitHubActivity {
-  user: string;
-  date: string;
-  period: string;
-  prs_created: PullRequest[];
-  prs_merged: PullRequest[];
-  prs_reviewed: PullRequest[];
-  issues_created: Issue[];
-  issues_closed: Issue[];
-  commits: Commit[];
-  repos_created: RepoInfo[];
-  repos_touched: string[];
+	user: string;
+	date: string;
+	period: string;
+	prs_created: PullRequest[];
+	prs_merged: PullRequest[];
+	prs_reviewed: PullRequest[];
+	issues_created: Issue[];
+	issues_closed: Issue[];
+	commits: Commit[];
+	repos_created: RepoInfo[];
+	repos_touched: string[];
 }
 
 export interface Options {
-  username?: string;
-  days: number;
-  english: boolean;
-  format: "slack" | "markdown" | "plain";
-  publicOnly: boolean;
-  interactive: boolean;
-  model?: string;
+	username?: string;
+	days: number;
+	english: boolean;
+	format: "slack" | "markdown" | "plain";
+	publicOnly: boolean;
+	interactive: boolean;
+	model?: string;
 }
 
 export type OutputFormat = "slack" | "markdown" | "plain";


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (Node 20/22 matrix)
- Add Biome for fast linting and formatting (replaces ESLint+Prettier)
- Add lint, lint:fix, format scripts to package.json
- Auto-format codebase (spaces → tabs, trailing commas, import sorting)

## Changes
| File | Description |
|------|-------------|
| `.github/workflows/ci.yml` | CI workflow: lint, typecheck, build on Node 20/22 |
| `biome.json` | Biome config with recommended rules |
| `package.json` | Added Biome + lint scripts |
| `src/*.ts` | Auto-formatted by Biome |

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [ ] CI workflow runs successfully on this PR

Closes #7