### PR TITLE
feat: add custom prompt option for Claude summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ That's it. Follow the prompts.
 ## Features
 
 - 📊 Summarizes PRs, reviews, commits, and issues
+- 📈 Tracks lines of code changed (additions/deletions)
 - 🤖 Powered by Claude AI for natural language summaries
+- 🎯 Custom prompt support for focused summaries
 - 🔄 Interactive or scripted mode
 - 📝 Multiple output formats (plain text, markdown, slack)
 - 🔒 Private repository support
+- 🏢 Organization/scope filtering
 - 🌍 English and German output
 
 ## Prerequisites
@@ -100,9 +103,12 @@ gh-tldr
 ? GitHub username (leave empty for authenticated user)
 ? Time period › Last 24 hours / Last 7 days / Last 30 days
 ? Language › English / German
+? Summary verbosity › Brief / Normal / Detailed
 ? Output format › Plain text / Markdown / Slack
 ? Include private repos? (y/N)
+? Filter by scope › All / org-name / username
 ? Claude model (leave empty for default)
+? Any specific focus for the summary? (optional)
 ```
 
 ### Direct Mode
@@ -116,8 +122,11 @@ gh-tldr [username] [options]
 | `-d, --days <n>` | Time period in days (default: 1) |
 | `-e, --english` | Output in English (default: German) |
 | `-f, --format <type>` | Output: `plain` \| `markdown` \| `slack` |
+| `-v, --verbosity <level>` | Summary length: `brief` \| `normal` \| `detailed` |
 | `-p, --public-only` | Exclude private repositories |
+| `-o, --orgs <orgs>` | Filter by organizations/accounts (comma-separated) |
 | `-m, --model <model>` | Claude model (e.g., haiku, sonnet, opus) |
+| `-P, --prompt <text>` | Custom instructions for Claude |
 | `-i, --interactive` | Force interactive mode |
 | `-h, --help` | Show help |
 
@@ -130,8 +139,14 @@ gh-tldr --days 7 --english
 # Specific user, public repos only
 gh-tldr yungweng --public-only
 
-# Use Haiku model for faster results
-gh-tldr --model haiku
+# Filter by organization
+gh-tldr --orgs my-company,my-org
+
+# Custom focus for standup
+gh-tldr -P "Focus on bug fixes and blockers"
+
+# Brief summary with Haiku model
+gh-tldr --verbosity brief --model haiku
 
 # Markdown output for documentation
 gh-tldr --days 30 --format markdown
@@ -147,6 +162,7 @@ tl;dr 28.12.2025
 • 2 PRs merged (repo-a)
 • 1 issue closed (repo-d)
 • 12 commits (repo-a, repo-b)
+• +1,234 / -567 lines changed (15 files)
 
 Repos: org/repo-a, org/repo-b, org/repo-c, org/repo-d
 

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -7,16 +7,26 @@ const wordLimits: Record<Verbosity, Record<Language, string>> = {
 	detailed: { en: "150-200 word", de: "150-200 Wörter" },
 };
 
-function buildPrompt(lang: Language, verbosity: Verbosity): string {
+function buildPrompt(
+	lang: Language,
+	verbosity: Verbosity,
+	customPrompt?: string,
+): string {
 	const limit = wordLimits[verbosity][lang];
 
+	const customSection = customPrompt?.trim()
+		? lang === "en"
+			? `\n\nAdditional focus: ${customPrompt}`
+			: `\n\nZusätzlicher Fokus: ${customPrompt}`
+		: "";
+
 	if (lang === "en") {
-		return `Based on this GitHub activity data, write a summary of what was accomplished. STRICT LIMIT: ${limit}. Mention specific PR/issue titles. If stats are available, include the lines of code changed (additions/deletions) as a brief mention. Casual tone, no bullet points, no emojis.
+		return `Based on this GitHub activity data, write a summary of what was accomplished. STRICT LIMIT: ${limit}. Mention specific PR/issue titles. If stats are available, include the lines of code changed (additions/deletions) as a brief mention. Casual tone, no bullet points, no emojis.${customSection}
 
 GitHub Activity Data:`;
 	}
 
-	return `Basierend auf diesen GitHub-Aktivitätsdaten, schreibe eine Zusammenfassung was gemacht wurde. STRIKTES LIMIT: ${limit}. Erwähne konkret die PR/Issue-Titel. Falls Stats verfügbar sind, erwähne kurz die geänderten Codezeilen (Additions/Deletions). Lockerer Ton, keine Aufzählungen, keine Emojis.
+	return `Basierend auf diesen GitHub-Aktivitätsdaten, schreibe eine Zusammenfassung was gemacht wurde. STRIKTES LIMIT: ${limit}. Erwähne konkret die PR/Issue-Titel. Falls Stats verfügbar sind, erwähne kurz die geänderten Codezeilen (Additions/Deletions). Lockerer Ton, keine Aufzählungen, keine Emojis.${customSection}
 
 GitHub-Aktivitätsdaten:`;
 }
@@ -26,8 +36,9 @@ export async function generateSummaryText(
 	lang: Language,
 	verbosity: Verbosity = "normal",
 	model?: string,
+	customPrompt?: string,
 ): Promise<string> {
-	const prompt = buildPrompt(lang, verbosity);
+	const prompt = buildPrompt(lang, verbosity, customPrompt);
 	const fullPrompt = `${prompt}\n${JSON.stringify(activity, null, 2)}`;
 
 	const args = ["-p", "-", "--output-format", "text"];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,6 +60,7 @@ interface CliOptions {
 	verbosity: string;
 	orgs?: string;
 	model?: string;
+	prompt?: string;
 }
 
 function validateVerbosity(value: string): Verbosity {
@@ -76,6 +77,7 @@ async function execute(
 	verbosity: Verbosity,
 	filterOrgs: string[] | null,
 	model?: string,
+	customPrompt?: string,
 ): Promise<void> {
 	// Resolve username
 	const resolvedUsername = username || (await getAuthenticatedUser());
@@ -117,6 +119,7 @@ async function execute(
 		lang,
 		verbosity,
 		model,
+		customPrompt,
 	);
 
 	console.log("");
@@ -156,6 +159,10 @@ export async function run(): Promise<void> {
 			"-m, --model <model>",
 			"Claude model to use (e.g., sonnet, opus, haiku)",
 		)
+		.option(
+			"-P, --prompt <text>",
+			"Custom instructions for Claude to consider when summarizing",
+		)
 		.action(async (username: string | undefined, options: CliOptions) => {
 			try {
 				await checkDependencies();
@@ -176,6 +183,7 @@ export async function run(): Promise<void> {
 						answers.verbosity,
 						answers.selectedOrgs,
 						answers.model || undefined,
+						answers.customPrompt || undefined,
 					);
 				} else {
 					// Direct mode
@@ -200,6 +208,7 @@ export async function run(): Promise<void> {
 						validateVerbosity(options.verbosity),
 						filterOrgs && filterOrgs.length > 0 ? filterOrgs : null,
 						options.model,
+						options.prompt,
 					);
 				}
 			} catch (error) {

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -11,6 +11,7 @@ interface InteractiveOptions {
 	includePrivate: boolean;
 	selectedOrgs: string[] | null;
 	model: string;
+	customPrompt: string;
 }
 
 export async function runInteractive(): Promise<InteractiveOptions> {
@@ -90,6 +91,11 @@ export async function runInteractive(): Promise<InteractiveOptions> {
 		default: "",
 	});
 
+	const customPrompt = await input({
+		message: "Any specific focus for the summary? (optional)",
+		default: "",
+	});
+
 	return {
 		username,
 		days,
@@ -99,5 +105,6 @@ export async function runInteractive(): Promise<InteractiveOptions> {
 		includePrivate,
 		selectedOrgs,
 		model,
+		customPrompt,
 	};
 }


### PR DESCRIPTION
## Summary

- Add `-P, --prompt <text>` CLI option for custom instructions
- Add optional text input in interactive mode for custom focus
- Inject user instructions into Claude prompt as "Additional focus" section

## Usage

**CLI:**
```bash
gh-tldr -P "Focus on bug fixes and code reviews"
gh-tldr yungweng -d 7 --prompt "Highlight collaboration work"
```

**Interactive mode:**
```
? Any specific focus for the summary? (optional)
  > Focus on the authentication work and mention blockers
```

## Test plan

- [x] Run `gh-tldr -P "Focus on bug fixes"` and verify custom focus appears in summary
- [x] Run `gh-tldr -i` and test the new interactive prompt (skip and with input)
- [x] Run `gh-tldr` without `-P` flag to verify backwards compatibility

Closes #17